### PR TITLE
emit NotificationFailed on critical failure

### DIFF
--- a/src/IntercomChannel.php
+++ b/src/IntercomChannel.php
@@ -5,6 +5,7 @@ namespace FtwSoft\NotificationChannels\Intercom;
 use Intercom\IntercomClient;
 use Illuminate\Notifications\Notification;
 use GuzzleHttp\Exception\BadResponseException;
+use Illuminate\Notifications\Events\NotificationFailed;
 use FtwSoft\NotificationChannels\Intercom\Exceptions\RequestException;
 use FtwSoft\NotificationChannels\Intercom\Contracts\IntercomNotification;
 use FtwSoft\NotificationChannels\Intercom\Exceptions\InvalidArgumentException;
@@ -76,6 +77,12 @@ class IntercomChannel
                 $message->toArray()
             );
         } catch (BadResponseException $exception) {
+            event(new NotificationFailed($notifiable, $notification, $this, [
+                    'message' => $message,
+                    'error' => $exception->getMessage()
+                ])
+            );
+
             throw new RequestException($exception, $exception->getMessage(), $exception->getCode());
         }
     }

--- a/src/IntercomChannel.php
+++ b/src/IntercomChannel.php
@@ -79,7 +79,7 @@ class IntercomChannel
         } catch (BadResponseException $exception) {
             event(new NotificationFailed($notifiable, $notification, $this, [
                     'message' => $message,
-                    'error' => $exception->getMessage()
+                    'error' => $exception->getMessage(),
                 ])
             );
 

--- a/tests/Mocks/TestFakeApplication.php
+++ b/tests/Mocks/TestFakeApplication.php
@@ -2,6 +2,7 @@
 
 namespace FtwSoft\NotificationChannels\Intercom\Tests\Mocks;
 
+use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
@@ -24,7 +25,7 @@ class TestFakeApplication extends Container implements ApplicationContract
     /**
      * {@inheritdoc}
      */
-    public function environment()
+    public function environment(...$environments)
     {
     }
 
@@ -102,6 +103,174 @@ class TestFakeApplication extends Container implements ApplicationContract
      * {@inheritdoc}
      */
     public function getCachedPackagesPath()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bootstrapPath($path = '')
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configPath($path = '')
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function databasePath($path = '')
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function environmentPath()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resourcePath($path = '')
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storagePath()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveProvider($provider)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bootstrapWith(array $bootstrappers)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configurationIsCached()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function detectEnvironment(Closure $callback)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function environmentFile()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function environmentFilePath()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCachedConfigPath()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCachedRoutesPath()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocale()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNamespace()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProviders($provider)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasBeenBootstrapped()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadDeferredProviders()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadEnvironmentFrom($file)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function routesAreCached()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLocale($locale)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shouldSkipMiddleware()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function terminate()
     {
     }
 }


### PR DESCRIPTION
Taking inspiration from [here](https://github.com/laravel/framework/pull/14874) and [here](https://github.com/laravel-notification-channels/new-channels/issues/16) this modifies the channel to emit the `NotificationFailed` if there is a critial failure. 

I'm using this to back-peddle if I try to send a message via email to a user's email and get back: 

```
FtwSoft/NotificationChannels/Intercom/Exceptions/RequestException with message 'Client error: `POST https://api.intercom.io/messages` resulted in a `409 Conflict` response:
{"type":"error.list","request_id":"0002caq9aec3fsla24r0","errors":[{"code":"conflict","message":"Multiple existing users (truncated...)
```

I'm happy to add tests for this if you want, but the `IntercomChannelTest` test didn't seem to have access to the app, facades, or event mocks. Could use some guidance

Thanks